### PR TITLE
Issue 58: Get code coverage working in Sonarcloud using JaCoCo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn verify sonar:sonar
+        run: mvn verify sonar:sonar -Pjacoco-code-coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Maven
-        run: mvn clean install -Pintegration-tests
+#        run: mvn clean install -Pintegration-tests
+        run: mvn clean install -Pjacoco-code-coverage
 
   sonarqube:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -251,23 +251,8 @@
         <profile>
             <id>integration-tests</id>
 
-            <activation>
-                <property>
-                    <name>env.TRAVIS</name>
-                    <value>true</value>
-                </property>
-            </activation>
-
             <build>
                 <plugins>
-                    <!--
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>${jacoco.agent.arg}</argLine>
-                        </configuration>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
@@ -276,7 +261,9 @@
                             <includes>
                                 <include>**/*IT.java</include>
                             </includes>
-                            <argLine>${jacoco.agent.arg}</argLine>
+                            <excludes>
+                                <exclude>**/**Test.java</exclude>
+                            </excludes>
                         </configuration>
                         <executions>
                             <execution>
@@ -295,6 +282,30 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jacoco-code-coverage</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                        <configuration>
+                            <argLine>${jacoco.agent.arg}</argLine>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                        <configuration>
+                            <argLine>${jacoco.agent.arg}</argLine>
+                        </configuration>
+                    </plugin>
 
                     <plugin>
                         <groupId>org.jacoco</groupId>
@@ -302,7 +313,7 @@
                         <version>0.8.5</version>
 
                         <executions>
-                            &lt;!&ndash; Prepare execution with Surefire &ndash;&gt;
+                            <!-- Prepare execution with Surefire -->
                             <execution>
                                 <id>pre-unit-test</id>
                                 <goals>
@@ -313,7 +324,7 @@
                                     <append>true</append>
                                 </configuration>
                             </execution>
-                            &lt;!&ndash; Generate report after tests are run &ndash;&gt;
+                            <!-- Generate report after tests are run -->
                             <execution>
                                 <id>post-unit-test</id>
                                 <phase>integration-test</phase>
@@ -323,7 +334,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    -->
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
# Pull Request Description

This pull request closes #58 .

Applied the necessary changes. In order to trigger code coverage, you will need to active the Maven profile for JaCoCo like this:
```
mvn clean install -Pjacoco-code-coverage
```

# Acceptance Test

* [ ] Building the code with `mvn clean install -Pintegration-tests` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [x] No
