### PR TITLE
Fix the failing integration tests

### DIFF
--- a/src/main/java/org/carlspring/cloud/storage/s3fs/AmazonS3Factory.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/AmazonS3Factory.java
@@ -20,6 +20,8 @@ import com.amazonaws.services.s3.S3ClientOptions;
 public abstract class AmazonS3Factory
 {
 
+    public static final String REGION = "s3fs_region";
+
     public static final String ACCESS_KEY = "s3fs_access_key";
 
     public static final String SECRET_KEY = "s3fs_secret_key";

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/AmazonS3ClientIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/AmazonS3ClientIT.java
@@ -9,15 +9,17 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import org.junit.Before;
 import org.junit.Test;
 import static java.util.UUID.randomUUID;
-import static org.carlspring.cloud.storage.s3fs.AmazonS3Factory.ACCESS_KEY;
-import static org.carlspring.cloud.storage.s3fs.AmazonS3Factory.SECRET_KEY;
+import static org.carlspring.cloud.storage.s3fs.AmazonS3Factory.*;
 import static org.carlspring.cloud.storage.s3fs.util.EnvironmentBuilder.getRealEnv;
 import static org.junit.Assert.assertNotNull;
 
@@ -31,12 +33,16 @@ public class AmazonS3ClientIT
     public void setup()
     {
         // s3client
-        final Map<String, Object> credentials = getRealEnv();
+        final Map<String, Object> env = getRealEnv();
 
-        BasicAWSCredentials credentialsS3 = new BasicAWSCredentials(credentials.get(ACCESS_KEY).toString(),
-                                                                    credentials.get(SECRET_KEY).toString());
+        BasicAWSCredentials credentialsS3 = new BasicAWSCredentials(env.get(ACCESS_KEY).toString(),
+                                                                    env.get(SECRET_KEY).toString());
 
-        client = new com.amazonaws.services.s3.AmazonS3Client(credentialsS3);
+        AWSCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(credentialsS3);
+
+        client = AmazonS3ClientBuilder.standard()
+                                      .withCredentials(credentialsProvider)
+                                      .withRegion(env.get(REGION).toString()).build();
     }
 
     @Test

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/util/EnvironmentBuilder.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/util/EnvironmentBuilder.java
@@ -8,8 +8,7 @@ import java.util.Properties;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.http.client.utils.URIBuilder;
-import static org.carlspring.cloud.storage.s3fs.AmazonS3Factory.ACCESS_KEY;
-import static org.carlspring.cloud.storage.s3fs.AmazonS3Factory.SECRET_KEY;
+import static org.carlspring.cloud.storage.s3fs.AmazonS3Factory.*;
 
 /**
  * Test Helper
@@ -31,10 +30,11 @@ public abstract class EnvironmentBuilder
 
         String accessKey = System.getenv(ACCESS_KEY);
         String secretKey = System.getenv(SECRET_KEY);
+        String region = System.getProperty(REGION);
 
-        if (accessKey != null && secretKey != null)
+        if (accessKey != null && secretKey != null && region != null)
         {
-            env = ImmutableMap.<String, Object>builder().put(ACCESS_KEY, accessKey).put(SECRET_KEY, secretKey).build();
+            env = ImmutableMap.<String, Object>builder().put(ACCESS_KEY, accessKey).put(SECRET_KEY, secretKey).put(REGION, region).build();
         }
         else
         {
@@ -50,8 +50,9 @@ public abstract class EnvironmentBuilder
             }
 
             env = ImmutableMap.<String, Object>builder().put(ACCESS_KEY, props.getProperty(ACCESS_KEY))
-                                                        .put(SECRET_KEY, props.getProperty(SECRET_KEY))
-                                                        .build();
+                                           .put(SECRET_KEY, props.getProperty(SECRET_KEY))
+                                           .put(REGION, props.getProperty(REGION))
+                                           .build();
         }
 
         return env;

--- a/src/test/resources/amazon-test-sample.properties
+++ b/src/test/resources/amazon-test-sample.properties
@@ -4,5 +4,7 @@
 
 bucket_name=/your-bucket-name-for-test
 # http://docs.aws.amazon.com/general/latest/gr/rande.html 
-s3fs_secret_key=secret-key-for-test
 s3fs_access_key=access-key-for-test
+s3fs_secret_key=secret-key-for-test
+# check com.amazonaws.regions.Regions for quick list
+s3fs_region=eu-central-1


### PR DESCRIPTION
# Pull Request Description

This pull request closes #59 

The reason for the failures was old code which was deprecated long time ago in the s3 client.
This PR also includes an env option to configure the `REGION` since this is now required for the client to work.

# Acceptance Test

* [x] Building the code with `mvn clean install -Pintegration-tests` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [x] No
